### PR TITLE
Audit fixes

### DIFF
--- a/contracts/BridgeConnectorWormhole.vy
+++ b/contracts/BridgeConnectorWormhole.vy
@@ -16,6 +16,8 @@ wormhole_token_bridge: public(address)
 
 @external
 def __init__(wormhole_token_bridge: address):
+    assert wormhole_token_bridge != ZERO_ADDRESS, "bridge is zero address"
+
     self.wormhole_token_bridge = wormhole_token_bridge
 
 
@@ -29,6 +31,7 @@ def __init__(wormhole_token_bridge: address):
 #
 # See target method signature: https://etherscan.io/address/0x6c4c12987303b2c94b2c76c612fc5f4d2f0360f7#code#F2#L93
 @internal
+@payable
 def _transfer_asset(_bridge: address, _asset: address, _amount: uint256, _recipient: bytes32, _extra_data: Bytes[1024]):
     nonce: uint256 = 0
     arbiter_fee: uint256 = 0
@@ -41,7 +44,7 @@ def _transfer_asset(_bridge: address, _asset: address, _amount: uint256, _recipi
     if len(_extra_data) >= 64:
         arbiter_fee = extract32(_extra_data, 32, output_type=uint256)
 
-    ERC20(_asset).approve(_bridge, _amount)
+    assert ERC20(_asset).approve(_bridge, _amount)
 
     raw_call(
         _bridge,
@@ -53,17 +56,20 @@ def _transfer_asset(_bridge: address, _asset: address, _amount: uint256, _recipi
             _recipient,
             convert(arbiter_fee, bytes32),
             convert(nonce, bytes32)
-        )
+        ),
+        value=msg.value
     )
 
 
 # Submits amount of bETH tokens to Terra address via token bridge.
 @external
+@payable
 def forward_beth(_terra_address: bytes32, _amount: uint256, _extra_data: Bytes[1024]):
     self._transfer_asset(self.wormhole_token_bridge, BETH_TOKEN, _amount, _terra_address, _extra_data)
 
 # Submits amount of UST tokens to Terra address via token bridge.
 @external
+@payable
 def forward_ust(_terra_address: bytes32, _amount: uint256, _extra_data: Bytes[1024]):
     self._transfer_asset(self.wormhole_token_bridge, UST_WRAPPER_TOKEN, _amount, _terra_address, _extra_data)
 

--- a/contracts/test_helpers/MockWormholeTokenBridge.sol
+++ b/contracts/test_helpers/MockWormholeTokenBridge.sol
@@ -3,10 +3,10 @@
 pragma solidity ^0.8.0;
 
 contract MockWormholeTokenBridge {
-    event WormholeTransfer(address indexed token, uint256 amount, uint16 indexed recipientChain, bytes32 indexed recipient, uint256 arbiterFee, uint32 nonce);
+    event WormholeTransfer(address indexed token, uint256 amount, uint16 indexed recipientChain, bytes32 indexed recipient, uint256 arbiterFee, uint32 nonce, uint256 value);
 
     function transferTokens(address token, uint256 amount, uint16 recipientChain, bytes32 recipient, uint256 arbiterFee, uint32 nonce) public payable returns (uint64 sequence) {
-        emit WormholeTransfer(token, amount, recipientChain, recipient, arbiterFee, nonce);
+        emit WormholeTransfer(token, amount, recipientChain, recipient, arbiterFee, nonce, msg.value);
 
         sequence = 0xFFFFFFFFFFFFFFFF;
     }

--- a/tests/test_connector_wormhole.py
+++ b/tests/test_connector_wormhole.py
@@ -1,5 +1,5 @@
 import pytest
-from brownie import reverts
+from brownie import ZERO_ADDRESS, reverts, Wei, AnchorVault
 
 TERRA_CHAIN_ID = 3
 TERRA_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd'
@@ -16,6 +16,12 @@ def bridge_connector(
         {'from': deployer}
     )
 
+def test_bridge_connector_wormhole_requires_non_zero_address(
+    deployer,
+    BridgeConnectorWormhole
+):
+    with reverts("bridge is zero address"):
+        BridgeConnectorWormhole.deploy(ZERO_ADDRESS, {'from': deployer})
 
 def test_anchor_vault_submit(
     vault, 
@@ -37,15 +43,17 @@ def test_anchor_vault_submit(
         'recipient': TERRA_ADDRESS,
         'arbiterFee': 0,
         'nonce': 0,
+        'value': 0,
     })
 
 
 @pytest.mark.parametrize(
-    'amount,extra_data,expected_amount,expected_arbiter_fee,expected_nonce',
+    'amount,extra_data,eth_msg_value,expected_amount,expected_arbiter_fee,expected_nonce',
     [
         (
             1 * 10**18,
             '0x00000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            Wei("1 ether"),
             1 * 10**18,
             115792089237316195423570985008687907853269984665640564039457584007913129639935,
             4294967295
@@ -53,6 +61,7 @@ def test_anchor_vault_submit(
         (
             500,
             '0x0000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            Wei("5 gwei"),
             500,
             115792089237316195423570985008687907853269984665640564039457584007913129639935,
             0
@@ -60,6 +69,7 @@ def test_anchor_vault_submit(
         (
             100,
             '0x00000000000000000000000000000000000000000000000000000000ffffffff',
+            Wei("100"),
             100,
             0,
             4294967295
@@ -67,24 +77,27 @@ def test_anchor_vault_submit(
         (
             0,
             '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+            Wei("0"),
             0,
             0,
             0
         ),
-        (0, '', 0, 0, 0),
+        (0, '', Wei("0"), 0, 0, 0),
     ]
 )
 def test_forward_beth_positive(
+    vault_user,
     helpers,
     bridge_connector,
     mock_wormhole_token_bridge,
     amount,
     extra_data,
+    eth_msg_value,
     expected_amount,
     expected_arbiter_fee,
     expected_nonce
 ):
-    tx = bridge_connector.forward_beth(TERRA_ADDRESS, amount, extra_data)
+    tx = bridge_connector.forward_beth(TERRA_ADDRESS, amount, extra_data, { 'from': vault_user, 'value': eth_msg_value })
 
     helpers.assert_single_event_named('WormholeTransfer', tx, source=mock_wormhole_token_bridge, evt_keys_dict={
         'token': BETH_TOKEN,
@@ -93,6 +106,7 @@ def test_forward_beth_positive(
         'recipient': TERRA_ADDRESS,
         'arbiterFee': expected_arbiter_fee,
         'nonce': expected_nonce,
+        'value': eth_msg_value,
     })
 
 
@@ -119,11 +133,12 @@ def test_forward_beth_negative(
 
 
 @pytest.mark.parametrize(
-    'amount,extra_data,expected_amount,expected_arbiter_fee,expected_nonce',
+    'amount,extra_data,eth_msg_value,expected_amount,expected_arbiter_fee,expected_nonce',
     [
         (
             1 * 10**18,
             '0x00000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            Wei("1 ether"),
             1 * 10**18,
             115792089237316195423570985008687907853269984665640564039457584007913129639935,
             4294967295
@@ -131,6 +146,7 @@ def test_forward_beth_negative(
         (
             500,
             '0x0000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            Wei("5 gwei"),
             500,
             115792089237316195423570985008687907853269984665640564039457584007913129639935,
             0
@@ -138,6 +154,7 @@ def test_forward_beth_negative(
         (
             100,
             '0x00000000000000000000000000000000000000000000000000000000ffffffff',
+            Wei("100"),
             100,
             0,
             4294967295
@@ -145,25 +162,28 @@ def test_forward_beth_negative(
         (
             0,
             '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+            Wei("0"),
             0,
             0,
             0
         ),
-        (0, '', 0, 0, 0),
+        (0, '', Wei("0"), 0, 0, 0),
     ]
 )
 def test_forward_ust_positive(
+    vault_user,
     ust_token,
     helpers,
     bridge_connector,
     mock_wormhole_token_bridge,
     amount,
     extra_data,
+    eth_msg_value,
     expected_amount,
     expected_arbiter_fee,
     expected_nonce
 ):
-    tx = bridge_connector.forward_ust(TERRA_ADDRESS, amount, extra_data)
+    tx = bridge_connector.forward_ust(TERRA_ADDRESS, amount, extra_data, { 'from': vault_user, 'value': eth_msg_value })
 
     helpers.assert_single_event_named('WormholeTransfer', tx, source=mock_wormhole_token_bridge, evt_keys_dict={
         'token': ust_token.address,
@@ -172,6 +192,7 @@ def test_forward_ust_positive(
         'recipient': TERRA_ADDRESS,
         'arbiterFee': expected_arbiter_fee,
         'nonce': expected_nonce,
+        'value': eth_msg_value,
     })
 
 


### PR DESCRIPTION
## Preface
This PR contains changes to address audit findings on `BridgeConnectorWormhole` contract.

## Changes
- [x] **Require a non-zero address for bridge argument in constructor and check ERC20 `approve()` call with assert.** Two target ERC20 contracts ([bETH](https://etherscan.io/address/0x707f9118e33a9b8998bea41dd0d46f38bb963fc8#code) and [WrappedUST](https://etherscan.io/address/0xa47c8bf37f92aBed4A126BDA807A7b7498661acD#code)) are called via `approve()` method. Return values of `approve()` calls should be checked by the common practice. However both of those implementations will return `true` by default, except `WrappedUST`, that will **revert** in case of `owner` or `spender` arguments will have zero address value. As `BridgeConnectorWormhole` passes an address from `wormhole_token_bridge` state variable, the value should always be a non-zero for `forward_ust()` to not revert during ERC20 approval process. The value for `wormhole_token_bridge` is set only in constructor, so there is now also a check that connector contract refers to a non-zero address. This would result that `forward_ust()` will not be locked by calling `approve()` on WrappedUST contract.
- [x] **Propagating call value to bridge.** Wormhole token bridge requires message fee to perform transfers. `BridgeConnectorWormhole` is now allowing to pass amount of ether to satify bridge fee. While the message fee is currently set to zero, there would be no additional payment required to transfer. However, current changes are making connector future-proof when bridge governance will decide to change message fee.
- [x] Tweak affected tests to respect the above changes.

Regards.