### PR TITLE
Feat: implement insurance connector accoding to LIP-6

### DIFF
--- a/contracts/InsuranceConnector.vy
+++ b/contracts/InsuranceConnector.vy
@@ -8,18 +8,18 @@ interface SelfOwnedStETHBurner:
     def getCoverSharesBurnt() -> uint256: view
 
 
-self_owned_steth_burner: public(address)
+SELF_OWNDED_STETH_BURNER: immutable(address)
 
 
 @external
 def __init__(
-    self_owned_steth_burner: address
+    _self_owned_steth_burner: address
 ):
-    assert self_owned_steth_burner != ZERO_ADDRESS, "ZERO_BURNER_ADDRESS"
+    assert _self_owned_steth_burner != ZERO_ADDRESS, "ZERO_BURNER_ADDRESS"
 
-    self.self_owned_steth_burner = self_owned_steth_burner
+    SELF_OWNDED_STETH_BURNER = _self_owned_steth_burner
 
 @external
 @view
 def total_shares_burnt() -> uint256:
-    return SelfOwnedStETHBurner(self.self_owned_steth_burner).getCoverSharesBurnt()
+    return SelfOwnedStETHBurner(SELF_OWNDED_STETH_BURNER).getCoverSharesBurnt()

--- a/contracts/InsuranceConnector.vy
+++ b/contracts/InsuranceConnector.vy
@@ -1,9 +1,25 @@
-# @version 0.2.12
+# @version 0.3.1
 # @author skozin <info@lido.fi>
+# @author Eugene Mamin <TheDZhon@gmail.com>
 # @licence MIT
+
+
+interface SelfOwnedStETHBurner:
+    def getCoverSharesBurnt() -> uint256: view
+
+
+self_owned_steth_burner: public(address)
+
+
+@external
+def __init__(
+    self_owned_steth_burner: address
+):
+    assert self_owned_steth_burner != ZERO_ADDRESS, "ZERO_BURNER_ADDRESS"
+
+    self.self_owned_steth_burner = self_owned_steth_burner
 
 @external
 @view
 def total_shares_burnt() -> uint256:
-    # currently, applying insurance is not supported by the protocol
-    return 0
+    return SelfOwnedStETHBurner(self.self_owned_steth_burner).getCoverSharesBurnt()

--- a/contracts/test_helpers/MockSelfOwnedStETHBurner.vy
+++ b/contracts/test_helpers/MockSelfOwnedStETHBurner.vy
@@ -1,6 +1,11 @@
-# @version 0.2.12
+# @version 0.3.1
 
 total_shares_burnt: public(uint256)
+
+@external
+@view
+def getCoverSharesBurnt() -> uint256:
+    return self.total_shares_burnt
 
 @external
 def increment_total_shares_burnt(inc: uint256):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,11 +118,13 @@ def mock_bridge_connector(beth_token, deployer, mock_bridge, MockBridgeConnector
 def mock_rewards_liquidator(MockRewardsLiquidator, deployer):
     return MockRewardsLiquidator.deploy({'from': deployer})
 
+@pytest.fixture(scope='module')
+def mock_self_owned_steth_burner(MockSelfOwnedStETHBurner, deployer):
+    return MockSelfOwnedStETHBurner.deploy({'from': deployer})
 
 @pytest.fixture(scope='module')
-def mock_insurance_connector(MockInsuranceConnector, deployer):
-    return MockInsuranceConnector.deploy({'from': deployer})
-
+def mock_insurance_connector(mock_self_owned_steth_burner, deployer, InsuranceConnector):
+    return InsuranceConnector.deploy(mock_self_owned_steth_burner, {'from': deployer})
 
 @pytest.fixture(scope='module')
 def withdraw_from_terra(mock_bridge_connector, mock_bridge, beth_token):

--- a/tests/test_insurance.py
+++ b/tests/test_insurance.py
@@ -9,7 +9,7 @@ ANOTHER_TERRA_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcde
 
 
 @pytest.fixture(scope='module')
-def apply_insurance(lido, steth_burner, deployer, mock_insurance_connector):
+def apply_insurance(lido, steth_burner, deployer, mock_self_owned_steth_burner):
     def apply(steth_rebase_mult):
         # steth_in_share = total_eth / total_shares
         # mult * total_eth / total_shares = total_eth / (total_shares - shares_burnt)
@@ -20,7 +20,7 @@ def apply_insurance(lido, steth_burner, deployer, mock_insurance_connector):
         print(f'steth_to_burn: {steth_to_burn}')
         lido.submit(ZERO_ADDRESS, {'from': deployer, 'value': steth_to_burn + 100})
         lido.burnShares(deployer, shares_to_burn, {'from': steth_burner})
-        mock_insurance_connector.increment_total_shares_burnt(shares_to_burn)
+        mock_self_owned_steth_burner.increment_total_shares_burnt(shares_to_burn)
     return apply
 
 


### PR DESCRIPTION
Use `SelfOwnedStETHBurner` as an insurance application mechanism.

Context: https://research.lido.fi/t/lip-6-in-protocol-coverage-proposal/1468
See also: https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-6.md
