### PR TITLE
feat: contract API versioning

### DIFF
--- a/contracts/AnchorVault.vy
+++ b/contracts/AnchorVault.vy
@@ -130,6 +130,17 @@ def initialize(beth_token: address, steth_token: address, admin: address):
 
 
 @external
+@pure
+def version() -> uint256:
+    return 2
+
+
+@internal
+def _assert_version(_expected_version: uint256):
+    assert _expected_version == 2 # dev: unexpected contract version
+
+
+@external
 def change_admin(new_admin: address):
     """
     @dev Changes the admin address. Can only be called by the current admin address.
@@ -340,7 +351,12 @@ def can_deposit_or_withdraw() -> bool:
 
 @external
 @payable
-def submit(_amount: uint256, _terra_address: bytes32, _extra_data: Bytes[1024]) -> (uint256, uint256):
+def submit(
+    _amount: uint256,
+    _terra_address: bytes32,
+    _extra_data: Bytes[1024],
+    _expected_version: uint256
+) -> (uint256, uint256):
     """
     @dev Locks the `_amount` of provided ETH or stETH tokens in return for bETH tokens
          minted to the `_terra_address` address on the Terra blockchain.
@@ -357,6 +373,7 @@ def submit(_amount: uint256, _terra_address: bytes32, _extra_data: Bytes[1024]) 
     severe penalties inflicted on the Lido validators. You can obtain the current conversion
     rate by calling `AnchorVault.get_rate()`.
     """
+    self._assert_version(_expected_version)
     assert self._can_deposit_or_withdraw() # dev: share price changed
 
     steth_token: address = self.steth_token
@@ -391,7 +408,11 @@ def submit(_amount: uint256, _terra_address: bytes32, _extra_data: Bytes[1024]) 
 
 
 @external
-def withdraw(_amount: uint256, _recipient: address = msg.sender) -> uint256:
+def withdraw(
+    _amount: uint256,
+    _expected_version: uint256,
+    _recipient: address = msg.sender
+) -> uint256:
     """
     @dev Burns the `_amount` of provided Ethereum-side bETH tokens in return for stETH
          tokens transferred to the `_recipient` Ethereum address.
@@ -405,6 +426,7 @@ def withdraw(_amount: uint256, _recipient: address = msg.sender) -> uint256:
     severe penalties inflicted on the Lido validators. You can obtain the current conversion
     rate by calling `AnchorVault.get_rate()`.
     """
+    self._assert_version(_expected_version)
     assert self._can_deposit_or_withdraw() # dev: share price changed
 
     steth_rate: uint256 = self._get_rate(True)

--- a/contracts/AnchorVault.vy
+++ b/contracts/AnchorVault.vy
@@ -118,8 +118,6 @@ def initialize(beth_token: address, steth_token: address, admin: address):
     assert beth_token != ZERO_ADDRESS # dev: invalid bETH address
     assert steth_token != ZERO_ADDRESS # dev: invalid stETH address
 
-    assert ERC20(beth_token).totalSupply() == 0 # dev: non-zero bETH total supply
-
     self.beth_token = beth_token
     self.steth_token = steth_token
     # we're explicitly allowing zero admin address for ossification

--- a/scripts/check_vault.py
+++ b/scripts/check_vault.py
@@ -187,7 +187,7 @@ def check_vault(
 
         terra_recipient_1 = '0x0000000000000000000000008badf00d8badf00d8badf00d8badf00d8badf00d'
         steth_token.approve(vault, 2 * 10**18, {'from': holder_1})
-        tx = vault.submit(2 * 10**18, terra_recipient_1, b'', {'from': holder_1})
+        tx = vault.submit(2 * 10**18, terra_recipient_1, b'', vault.version(), {'from': holder_1})
         # tx.info()
 
         assert 'Deposited' in tx.events
@@ -230,7 +230,7 @@ def check_vault(
         beth_supply_before = beth_supply
 
         terra_recipient_2 = '0x000000000000000000000000deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
-        tx = vault.submit(1 * 10**18, terra_recipient_2, b'', {'from': holder_2, 'value': 1 * 10**18})
+        tx = vault.submit(1 * 10**18, terra_recipient_2, b'', vault.version(), {'from': holder_2, 'value': 1 * 10**18})
         # tx.info()
 
         assert 'Deposited' in tx.events

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,7 +233,7 @@ def deposit_to_terra(vault, mock_bridge_connector, steth_token, helpers, steth_a
         steth_amount_adj = steth_adjusted_ammount(amount)
 
         steth_token.approve(vault, amount, {'from': sender})
-        tx = vault.submit(amount, terra_address, '0xab', {'from': sender})
+        tx = vault.submit(amount, terra_address, '0xab', vault.version(), {'from': sender})
 
         steth_balance_decrease = steth_balance_before - steth_token.balanceOf(sender)
         assert helpers.equal_with_precision(steth_balance_decrease, steth_amount_adj, max_diff=10**10)

--- a/tests/test_connector_wormhole.py
+++ b/tests/test_connector_wormhole.py
@@ -34,7 +34,7 @@ def test_anchor_vault_submit(
 
     steth_token.approve(vault, amount, {'from': vault_user})
 
-    tx = vault.submit(amount, TERRA_ADDRESS, '', {'from': vault_user})
+    tx = vault.submit(amount, TERRA_ADDRESS, '', vault.version(), {'from': vault_user})
 
     helpers.assert_single_event_named('WormholeTransfer', tx, source=mock_wormhole_token_bridge, evt_keys_dict={
         'token': BETH_TOKEN,

--- a/tests/test_insurance.py
+++ b/tests/test_insurance.py
@@ -38,7 +38,7 @@ def test_insurance_applied_before_rewards_collection_avoids_changing_rate(
     amount = steth_adjusted_ammount(10**18)
 
     steth_token.approve(vault, amount, {'from': vault_user})
-    vault.submit(amount, TERRA_ADDRESS, b'', {'from': vault_user})
+    vault.submit(amount, TERRA_ADDRESS, b'', vault.version(), {'from': vault_user})
 
     vault_steth_balance_before = steth_token.balanceOf(vault)
 
@@ -82,7 +82,7 @@ def test_insurance_is_not_counted_as_rewards(
     amount = steth_adjusted_ammount(10**18)
 
     steth_token.approve(vault, amount, {'from': vault_user})
-    vault.submit(amount, TERRA_ADDRESS, b'', {'from': vault_user})
+    vault.submit(amount, TERRA_ADDRESS, b'', vault.version(), {'from': vault_user})
 
     vault_steth_balance_before = steth_token.balanceOf(vault)
 

--- a/tests/test_rewards_liquidation.py
+++ b/tests/test_rewards_liquidation.py
@@ -325,7 +325,7 @@ def test_integrates_with_real_vault(
     adjusted_amount = steth_adjusted_ammount(amount)
 
     steth_token.approve(vault, amount, {"from": vault_user})
-    vault.submit(amount, TERRA_ADDRESS, b"", {"from": vault_user})
+    vault.submit(amount, TERRA_ADDRESS, b"", vault.version(), {"from": vault_user})
     assert mock_bridge_connector.terra_beth_balance_of(TERRA_ADDRESS) == adjusted_amount
 
     lido_oracle_report(steth_rebase_mult=1.01)

--- a/tests/test_vault_balance_rebases.py
+++ b/tests/test_vault_balance_rebases.py
@@ -12,7 +12,7 @@ def test_rate_changes(vault, lido_oracle_report, vault_user, liquidations_admin,
     assert vault.get_rate() == 10**18
 
     steth_token.approve(vault, 10**18, {'from': vault_user})
-    vault.submit(10**18, TERRA_ADDRESS, b'', {'from': vault_user})
+    vault.submit(10**18, TERRA_ADDRESS, b'', vault.version(), {'from': vault_user})
 
     assert helpers.equal_with_precision(
         vault.get_rate(),
@@ -92,15 +92,15 @@ def test_beth_io_possible_after_steth_io(
     steth_token.approve(vault, 2 * 10**18, {'from': vault_user})
 
     assert vault.can_deposit_or_withdraw()
-    vault.submit(10**18, TERRA_ADDRESS, b'', {'from': vault_user})
+    vault.submit(10**18, TERRA_ADDRESS, b'', vault.version(), {'from': vault_user})
 
     lido.submit(ZERO_ADDRESS, {'from': stranger, 'value': steth_io_amount})
 
     assert vault.can_deposit_or_withdraw()
-    vault.submit(10**18, TERRA_ADDRESS, b'', {'from': vault_user})
+    vault.submit(10**18, TERRA_ADDRESS, b'', vault.version(), {'from': vault_user})
 
     withdraw_from_terra(TERRA_ADDRESS, to_address=vault_user, amount=10**18)
-    vault.withdraw(10**18, {'from': vault_user})
+    vault.withdraw(10**18, vault.version(), {'from': vault_user})
 
 
 def test_beth_io_possible_after_non_rebasing_lido_oracle_report(
@@ -113,15 +113,15 @@ def test_beth_io_possible_after_non_rebasing_lido_oracle_report(
     steth_token.approve(vault, 2 * 10**18, {'from': vault_user})
 
     assert vault.can_deposit_or_withdraw()
-    vault.submit(10**18, TERRA_ADDRESS, b'', {'from': vault_user})
+    vault.submit(10**18, TERRA_ADDRESS, b'', vault.version(), {'from': vault_user})
 
     lido_oracle_report(steth_rebase_mult=1.0)
 
     assert vault.can_deposit_or_withdraw()
-    vault.submit(10**18, TERRA_ADDRESS, b'', {'from': vault_user})
+    vault.submit(10**18, TERRA_ADDRESS, b'', vault.version(), {'from': vault_user})
 
     withdraw_from_terra(TERRA_ADDRESS, to_address=vault_user, amount=10**18)
-    vault.withdraw(10**18, {'from': vault_user})
+    vault.withdraw(10**18, vault.version(), {'from': vault_user})
 
 
 # FIXME: use vault instead of vault_no_proxy after brownie learns to parse
@@ -136,25 +136,25 @@ def test_beth_io_prohibited_between_positive_rebase_by_oracle_report_and_rewards
     withdraw_from_terra
 ):
     steth_token.approve(vault_no_proxy, 100 * 10**18, {'from': vault_user})
-    vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', {'from': vault_user})
+    vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', vault_no_proxy.version(), {'from': vault_user})
 
     lido_oracle_report(steth_rebase_mult = 1 + 0.04/365)
 
     assert not vault_no_proxy.can_deposit_or_withdraw()
 
     with reverts('dev: share price changed'):
-        vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', {'from': vault_user})
+        vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', vault_no_proxy.version(), {'from': vault_user})
 
     withdraw_from_terra(TERRA_ADDRESS, to_address=vault_user, amount=10**18)
 
     with reverts('dev: share price changed'):
-        vault_no_proxy.withdraw(10**18, {'from': vault_user})
+        vault_no_proxy.withdraw(10**18, vault_no_proxy.version(), {'from': vault_user})
 
     vault_no_proxy.collect_rewards({'from': liquidations_admin})
     assert vault_no_proxy.can_deposit_or_withdraw()
 
-    vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', {'from': vault_user})
-    vault_no_proxy.withdraw(10**18, {'from': vault_user})
+    vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', vault_no_proxy.version(), {'from': vault_user})
+    vault_no_proxy.withdraw(10**18, vault_no_proxy.version(), {'from': vault_user})
 
 
 # FIXME: use vault instead of vault_no_proxy after brownie learns to parse
@@ -169,25 +169,25 @@ def test_beth_io_prohibited_between_negative_rebase_by_oracle_report_and_rewards
     withdraw_from_terra
 ):
     steth_token.approve(vault_no_proxy, 100 * 10**18, {'from': vault_user})
-    vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', {'from': vault_user})
+    vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', vault_no_proxy.version(), {'from': vault_user})
 
     lido_oracle_report(steth_rebase_mult = 1 - 0.00000004/365)
 
     assert not vault_no_proxy.can_deposit_or_withdraw()
 
     with reverts('dev: share price changed'):
-        vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', {'from': vault_user})
+        vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', vault_no_proxy.version(), {'from': vault_user})
 
     withdraw_from_terra(TERRA_ADDRESS, to_address=vault_user, amount=10**18)
 
     with reverts('dev: share price changed'):
-        vault_no_proxy.withdraw(10**18, {'from': vault_user})
+        vault_no_proxy.withdraw(10**18, vault_no_proxy.version(), {'from': vault_user})
 
     vault_no_proxy.collect_rewards({'from': liquidations_admin})
     assert vault_no_proxy.can_deposit_or_withdraw()
 
-    vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', {'from': vault_user})
-    vault_no_proxy.withdraw(10**18, {'from': vault_user})
+    vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', vault_no_proxy.version(), {'from': vault_user})
+    vault_no_proxy.withdraw(10**18, vault_no_proxy.version(), {'from': vault_user})
 
 
 # FIXME: use vault instead of vault_no_proxy after brownie learns to parse
@@ -204,25 +204,25 @@ def test_beth_io_prohibited_between_rebase_by_burning_steth_and_rewards_sell(
     withdraw_from_terra
 ):
     steth_token.approve(vault_no_proxy, 100 * 10**18, {'from': vault_user})
-    vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', {'from': vault_user})
+    vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', vault_no_proxy.version(), {'from': vault_user})
 
     burn_steth(another_vault_user, 10**18)
 
     assert not vault_no_proxy.can_deposit_or_withdraw()
 
     with reverts('dev: share price changed'):
-        vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', {'from': vault_user})
+        vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', vault_no_proxy.version(), {'from': vault_user})
 
     withdraw_from_terra(TERRA_ADDRESS, to_address=vault_user, amount=10**18)
 
     with reverts('dev: share price changed'):
-        vault_no_proxy.withdraw(10**18, {'from': vault_user})
+        vault_no_proxy.withdraw(10**18, vault_no_proxy.version(), {'from': vault_user})
 
     vault_no_proxy.collect_rewards({'from': liquidations_admin})
     assert vault_no_proxy.can_deposit_or_withdraw()
 
-    vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', {'from': vault_user})
-    vault_no_proxy.withdraw(10**18, {'from': vault_user})
+    vault_no_proxy.submit(10**18, TERRA_ADDRESS, b'', vault_no_proxy.version(), {'from': vault_user})
+    vault_no_proxy.withdraw(10**18, vault_no_proxy.version(), {'from': vault_user})
 
 
 def test_steth_positive_rebase(
@@ -241,7 +241,7 @@ def test_steth_positive_rebase(
     adjusted_amount = steth_adjusted_ammount(amount)
 
     steth_token.approve(vault, amount, {'from': vault_user})
-    vault.submit(amount, TERRA_ADDRESS, '0xab', {'from': vault_user})
+    vault.submit(amount, TERRA_ADDRESS, '0xab', vault.version(), {'from': vault_user})
     assert mock_bridge_connector.terra_beth_balance_of(TERRA_ADDRESS) == amount
 
     vault_steth_balance_before = steth_token.balanceOf(vault)
@@ -267,7 +267,7 @@ def test_steth_positive_rebase(
     )
 
     withdraw_from_terra(TERRA_ADDRESS, to_address=stranger, amount=amount)
-    vault.withdraw(amount, {'from': stranger})
+    vault.withdraw(amount, vault.version(), {'from': stranger})
 
     assert helpers.equal_with_precision(steth_token.balanceOf(stranger), adjusted_amount, 100)
 
@@ -288,7 +288,7 @@ def test_steth_negative_rebase(
     adjusted_amount = steth_adjusted_ammount(amount)
 
     steth_token.approve(vault, amount, {'from': vault_user})
-    vault.submit(amount, TERRA_ADDRESS, '0xab', {'from': vault_user})
+    vault.submit(amount, TERRA_ADDRESS, '0xab', vault.version(), {'from': vault_user})
     assert mock_bridge_connector.terra_beth_balance_of(TERRA_ADDRESS) == amount
 
     vault_steth_balance_before = steth_token.balanceOf(vault)
@@ -314,7 +314,7 @@ def test_steth_negative_rebase(
 
     assert helpers.equal_with_precision(vault.get_rate(), expected_withdraw_rate, 100)
 
-    vault.withdraw(amount, {'from': stranger})
+    vault.withdraw(amount, vault.version(), {'from': stranger})
 
     assert helpers.equal_with_precision(
         steth_token.balanceOf(stranger),
@@ -344,7 +344,7 @@ def test_steth_rewards_after_penalties(
     positive_rebase_multiplier = 1 / negative_rebase_multiplier
 
     steth_token.approve(vault, amount, {'from': vault_user})
-    vault.submit(amount, TERRA_ADDRESS, b'', {'from': vault_user})
+    vault.submit(amount, TERRA_ADDRESS, b'', vault.version(), {'from': vault_user})
    
     lido_oracle_report(steth_rebase_mult=negative_rebase_multiplier)
 
@@ -362,7 +362,7 @@ def test_steth_rewards_after_penalties(
     })
 
     steth_token.approve(vault, amount, {'from': another_vault_user})
-    vault.submit(amount, ANOTHER_TERRA_ADDRESS, b'', {'from': another_vault_user})
+    vault.submit(amount, ANOTHER_TERRA_ADDRESS, b'', vault.version(), {'from': another_vault_user})
     
     lido_oracle_report(steth_rebase_mult=positive_rebase_multiplier)
     chain.mine(timedelta = 3600*24 + 1)
@@ -373,7 +373,7 @@ def test_steth_rewards_after_penalties(
         to_address=stranger, 
         amount=mock_bridge_connector.terra_beth_balance_of(TERRA_ADDRESS)
     )
-    vault.withdraw(beth_token.balanceOf(stranger), {'from': stranger})
+    vault.withdraw(beth_token.balanceOf(stranger), vault.version(), {'from': stranger})
 
     assert helpers.equal_with_precision(
         steth_token.balanceOf(stranger),
@@ -386,7 +386,7 @@ def test_steth_rewards_after_penalties(
         to_address=another_stranger,
         amount=mock_bridge_connector.terra_beth_balance_of(ANOTHER_TERRA_ADDRESS)
     )
-    vault.withdraw(beth_token.balanceOf(another_stranger), {'from': another_stranger})
+    vault.withdraw(beth_token.balanceOf(another_stranger), vault.version(), {'from': another_stranger})
 
     assert helpers.equal_with_precision(
         steth_token.balanceOf(another_stranger),
@@ -477,7 +477,7 @@ def test_shares_balance_decrease_liquidation(
     vault.collect_rewards({'from': liquidations_admin})
 
     withdraw_from_terra(TERRA_ADDRESS, to_address=vault_user, amount=0.5 * 10**18)
-    vault.withdraw(0.5 * 10**18, {'from': vault_user})
+    vault.withdraw(0.5 * 10**18, vault.version(), {'from': vault_user})
     
     chain.mine(timedelta=3600*28)
 


### PR DESCRIPTION
Adds the `_expected_version` parameter to `submit` and `withdraw` functions, reverting if the passed value differs from the current contract version.

Adds the `version()` view function.