### PR TITLE
Feat: refund for the 2022-01-26 incident

### DIFF
--- a/contracts/AnchorVault.vy
+++ b/contracts/AnchorVault.vy
@@ -150,8 +150,8 @@ def _assert_version(_expected_version: uint256):
 
 
 @internal
-def _assert_authorized(msg_sender: address):
-    assert msg_sender == self.admin # dev: unauthorized
+def _assert_admin(addr: address):
+    assert addr == self.admin # dev: unauthorized
 
 
 @internal
@@ -197,7 +197,7 @@ def change_admin(new_admin: address):
 
     Setting the admin to zero ossifies the contract, i.e. makes it irreversibly non-administrable.
     """
-    self._assert_authorized(msg.sender)
+    self._assert_admin(msg.sender)
     # we're explicitly allowing zero admin address for ossification
     self.admin = new_admin
     log AdminChanged(new_admin)
@@ -213,7 +213,7 @@ def bump_version():
     this function when backwards-incompatible changes are made to the contract or its
     delegates.
     """
-    self._assert_authorized(msg.sender)
+    self._assert_admin(msg.sender)
     new_version: uint256 = self.version + 1
     self.version = new_version
     log VersionIncremented(new_version)
@@ -233,7 +233,7 @@ def set_bridge_connector(_bridge_connector: address):
 
     Can only be called by the current admin address.
     """
-    self._assert_authorized(msg.sender)
+    self._assert_admin(msg.sender)
     self._set_bridge_connector(_bridge_connector)
 
 
@@ -250,7 +250,7 @@ def set_rewards_liquidator(_rewards_liquidator: address):
 
     Can only be called by the current admin address.
     """
-    self._assert_authorized(msg.sender)
+    self._assert_admin(msg.sender)
     self._set_rewards_liquidator(_rewards_liquidator)
 
 
@@ -268,7 +268,7 @@ def set_insurance_connector(_insurance_connector: address):
 
     Can only be called by the current admin address.
     """
-    self._assert_authorized(msg.sender)
+    self._assert_admin(msg.sender)
     self._set_insurance_connector(_insurance_connector)
 
 
@@ -304,7 +304,7 @@ def set_liquidation_config(
 
     Can only be called by the current admin address.
     """
-    self._assert_authorized(msg.sender)
+    self._assert_admin(msg.sender)
     self._set_liquidation_config(
         _liquidations_admin,
         _no_liquidation_interval,
@@ -326,7 +326,7 @@ def set_anchor_rewards_distributor(_anchor_rewards_distributor: bytes32):
 
     Can only be called by the current admin address.
     """
-    self._assert_authorized(msg.sender)
+    self._assert_admin(msg.sender)
     self._set_anchor_rewards_distributor(_anchor_rewards_distributor)
 
 
@@ -345,7 +345,7 @@ def configure(
 
     Can only be called by the current admin address.
     """
-    self._assert_authorized(msg.sender)
+    self._assert_admin(msg.sender)
     self._set_bridge_connector(_bridge_connector)
     self._set_rewards_liquidator(_rewards_liquidator)
     self._set_insurance_connector(_insurance_connector)
@@ -575,7 +575,7 @@ def finalize_upgrade_v3():
 
     Can only be called by the current admin address.
     """
-    self._assert_authorized(msg.sender)
+    self._assert_admin(msg.sender)
     # in v2, the version() function returned constant value of 2; in the upgraded impl,
     # the same function reads a storage slot that's zero until this function is called
     self._assert_version(0)

--- a/contracts/AnchorVault.vy
+++ b/contracts/AnchorVault.vy
@@ -42,6 +42,13 @@ event Withdrawn:
     amount: uint256
 
 
+event Refunded:
+    recipient: indexed(address)
+    beth_amount: uint256
+    steth_amount: uint256
+    comment: String[1024]
+
+
 event RewardsCollected:
     steth_amount: uint256
     ust_amount: uint256
@@ -134,6 +141,8 @@ last_liquidation_shares_burnt: public(uint256)
 #
 version: public(uint256)
 
+total_beth_refunded: public(uint256)
+
 
 @internal
 def _assert_version(_expected_version: uint256):
@@ -178,20 +187,6 @@ def petrify_impl():
     """
     assert self.version == 0 # dev: already initialized
     self.version = MAX_UINT256
-
-
-@external
-def finalize_upgrade_v3():
-    """
-    @dev Performs state changes required for proxy upgrade from version 2 to version 3.
-
-    Can only be called by the current admin address.
-    """
-    self._assert_authorized(msg.sender)
-    # in v2, the version() function returned constant value of 2; in the upgraded impl,
-    # the same function reads a storage slot that's zero until this function is called
-    self._assert_version(0)
-    self._initialize_v3()
 
 
 
@@ -366,7 +361,7 @@ def configure(
 @view
 def _get_rate(_is_withdraw_rate: bool) -> uint256:
     steth_balance: uint256 = ERC20(self.steth_token).balanceOf(self)
-    beth_supply: uint256 = ERC20(self.beth_token).totalSupply()
+    beth_supply: uint256 = ERC20(self.beth_token).totalSupply() - self.total_beth_refunded
     if steth_balance >= beth_supply:
         return 10**18
     elif _is_withdraw_rate:
@@ -479,37 +474,113 @@ def submit(
     return (steth_amount_adj, beth_amount)
 
 
+@internal
+def _withdraw(recipient: address, beth_amount: uint256, steth_rate: uint256) -> uint256:
+    assert self._can_deposit_or_withdraw() # dev: share price changed
+    steth_amount: uint256 = (beth_amount * steth_rate) / 10**18
+    ERC20(self.steth_token).transfer(recipient, steth_amount)
+    return steth_amount
+
+
+
 @external
 def withdraw(
-    _amount: uint256,
+    _beth_amount: uint256,
     _expected_version: uint256,
     _recipient: address = msg.sender
 ) -> uint256:
     """
-    @dev Burns the `_amount` of provided Ethereum-side bETH tokens in return for stETH
+    @dev Burns the `_beth_amount` of provided Ethereum-side bETH tokens in return for stETH
          tokens transferred to the `_recipient` Ethereum address.
 
     To withdraw Terra-side bETH, you should firstly transfer the tokens to the Ethereum
     blockchain.
 
-    The call fails if `AnchorVault.can_deposit_or_withdraw()` is false.
+    The call fails if `AnchorVault.can_deposit_or_withdraw()` returns false.
 
     The conversion rate from stETH to bETH should normally be 1 but might be different after
     severe penalties inflicted on the Lido validators. You can obtain the current conversion
     rate by calling `AnchorVault.get_rate()`.
     """
     self._assert_version(_expected_version)
-    assert self._can_deposit_or_withdraw() # dev: share price changed
 
     steth_rate: uint256 = self._get_rate(True)
-    steth_amount: uint256 = (_amount * steth_rate) / 10**18
+    Mintable(self.beth_token).burn(msg.sender, _beth_amount)
+    steth_amount: uint256 = self._withdraw(_recipient, _beth_amount, steth_rate)
 
-    Mintable(self.beth_token).burn(msg.sender, _amount)
-    ERC20(self.steth_token).transfer(_recipient, steth_amount)
-
-    log Withdrawn(_recipient, _amount)
+    log Withdrawn(_recipient, _beth_amount)
 
     return steth_amount
+
+
+@internal
+def _withdraw_for_refunding_burned_beth(
+    _burned_beth_amount: uint256,
+    _recipient: address,
+    _comment: String[1024]
+) -> uint256:
+    """
+    @dev Withdraws stETH without burning the corresponding bETH, assuming that
+         the corresponding bETH was already effectively burned, i.e. that it
+         cannot be moved from the address it currently belongs to by any actor
+         at any current or future moment. Returns the amount of stETH withdrawn.
+
+    Can only be called by the current admin address. Used by the DAO governance
+    to refund bETH that is provably burned, e.g. by using an incorrect encoding
+    of the Terra recipient address. The governance takes the responsibility for
+    verifying the inaccessibility of the bETH being refunded.
+
+    The call fails if `AnchorVault.can_deposit_or_withdraw()` returns false.
+
+    The same conversion rate from bETH to stETH as in the `withdraw` method
+    is applied. The call doesn't change the conversion rate.
+    """
+    steth_rate: uint256 = self._get_rate(True)
+    self.total_beth_refunded += _burned_beth_amount
+    steth_amount: uint256 = self._withdraw(_recipient, _burned_beth_amount, steth_rate)
+
+    log Refunded(_recipient, _burned_beth_amount, steth_amount, _comment)
+
+    return steth_amount
+
+
+@internal
+def _perform_refund_for_2022_01_26_incident():
+    """
+    @dev Withdraws stETH corresponding to bETH irreversibly locked at inaccessible Terra
+         addresses as the result of the 2022-01-26 incident caused by incorrect address
+         encoding produced by cached UI code after onchain migration to the Wormhole bridge.
+
+    Tx 1: 0xc875f85f525d9bc47314eeb8dc13c288f0814cf06865fc70531241e21f5da09d
+    bETH burned: 4449999990000000000
+
+    Tx 2: 0x7abe086dd5619a577f50f87660a03ea0a1934c4022cd432ddf00734771019951
+    bETH burned: 439111118580000000000
+    """
+    # prevent this funciton from being called after the v3 upgrade (see `finalize_upgrade_v3`)
+    self._assert_version(0)
+    LIDO_DAO_FINANCE_MULTISIG: address = 0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb
+    BETH_AMOUNT_BURNED: uint256 = 4449999990000000000 + 439111118580000000000
+    self._withdraw_for_refunding_burned_beth(
+        BETH_AMOUNT_BURNED,
+        LIDO_DAO_FINANCE_MULTISIG,
+        "refund for 2022-01-26 incident, txid 0x7abe086dd5619a577f50f87660a03ea0a1934c4022cd432ddf00734771019951 and 0xc875f85f525d9bc47314eeb8dc13c288f0814cf06865fc70531241e21f5da09d"
+    )
+
+
+@external
+def finalize_upgrade_v3():
+    """
+    @dev Performs state changes required for proxy upgrade from version 2 to version 3.
+
+    Can only be called by the current admin address.
+    """
+    self._assert_authorized(msg.sender)
+    # in v2, the version() function returned constant value of 2; in the upgraded impl,
+    # the same function reads a storage slot that's zero until this function is called
+    self._assert_version(0)
+    self._perform_refund_for_2022_01_26_incident()
+    self._initialize_v3()
 
 
 @external

--- a/tests/test_upgrade_v3.py
+++ b/tests/test_upgrade_v3.py
@@ -1,6 +1,8 @@
 import pytest
 from brownie import accounts, interface, Contract, AnchorVault, reverts, chain, ZERO_ADDRESS
 
+from utils.config import beth_token_addr, wormhole_token_bridge_addr
+
 """
 These tests should be ran on a mainnet block produced
 before the v3 upgrade, e.g. on the block 14158645.
@@ -33,6 +35,11 @@ def vault_proxy(AnchorVaultProxy):
     assert vault.version() == 2
     assert vault.admin() == proxy.proxy_getAdmin()
     return proxy
+
+
+@pytest.fixture(scope='module')
+def beth_token(bEth):
+    return bEth.at(beth_token_addr)
 
 
 def test_initialize_cannot_be_called_after_upgrading_impl(
@@ -134,3 +141,100 @@ def test_cannot_finalize_upgrade_twice(vault_proxy, stranger, vault_admin):
 
     with reverts():
         vault.finalize_upgrade_v3({'from': stranger})
+
+
+def test_admin_can_burn_the_refunded_beth(vault_proxy, beth_token, stranger, vault_admin, helpers):
+    upgrade_vault_to_v3(vault_proxy, impl_deployer=stranger)
+    vault = as_vault_v3(vault_proxy)
+
+    beth_total_supply_before = beth_token.totalSupply()
+    beth_rate_before = vault.get_rate()
+
+    # simulate the unlock of the refunded bETH
+    token_bridge = accounts.at(wormhole_token_bridge_addr, force=True)
+    beth_token.transfer(vault, REFUND_BETH_AMOUNT, {'from': token_bridge})
+
+    tx = vault.burn_refunded_beth(REFUND_BETH_AMOUNT, {'from': vault_admin})
+
+    assert beth_token.totalSupply() == beth_total_supply_before - REFUND_BETH_AMOUNT
+    assert vault.get_rate() == beth_rate_before
+
+    helpers.assert_single_event_named('RefundedBethBurned', tx, source=vault, evt_keys_dict={
+        'beth_amount': REFUND_BETH_AMOUNT
+    })
+
+
+def test_admin_can_burn_the_refunded_beth_in_two_chunks(
+    vault_proxy,
+    beth_token,
+    stranger,
+    vault_admin,
+    helpers
+):
+    upgrade_vault_to_v3(vault_proxy, impl_deployer=stranger)
+    vault = as_vault_v3(vault_proxy)
+
+    beth_total_supply_before = beth_token.totalSupply()
+    beth_rate_before = vault.get_rate()
+
+    beth_amount_unlock_1 = REFUND_BETH_AMOUNT // 3
+    beth_amount_unlock_2 = REFUND_BETH_AMOUNT - beth_amount_unlock_1
+
+    # simulate the unlock of the refunded bETH
+    token_bridge = accounts.at(wormhole_token_bridge_addr, force=True)
+
+    beth_token.transfer(vault, beth_amount_unlock_1, {'from': token_bridge})
+    tx_1 = vault.burn_refunded_beth(beth_amount_unlock_1, {'from': vault_admin})
+
+    assert beth_token.totalSupply() == beth_total_supply_before - beth_amount_unlock_1
+    assert vault.get_rate() == beth_rate_before
+
+    helpers.assert_single_event_named('RefundedBethBurned', tx_1, source=vault, evt_keys_dict={
+        'beth_amount': beth_amount_unlock_1
+    })
+
+    beth_token.transfer(vault, beth_amount_unlock_2, {'from': token_bridge})
+    tx_2 = vault.burn_refunded_beth(beth_amount_unlock_2, {'from': vault_admin})
+
+    assert beth_token.totalSupply() == beth_total_supply_before - REFUND_BETH_AMOUNT
+    assert vault.get_rate() == beth_rate_before
+
+    helpers.assert_single_event_named('RefundedBethBurned', tx_2, source=vault, evt_keys_dict={
+        'beth_amount': beth_amount_unlock_2
+    })
+
+
+def test_cannot_burn_more_than_the_refunded_amount(vault_proxy, beth_token, stranger, vault_admin):
+    upgrade_vault_to_v3(vault_proxy, impl_deployer=stranger)
+    vault = as_vault_v3(vault_proxy)
+
+    # simulate the unlock of the refunded bETH
+    token_bridge = accounts.at(wormhole_token_bridge_addr, force=True)
+    beth_token.transfer(vault, REFUND_BETH_AMOUNT, {'from': token_bridge})
+
+    with reverts():
+        vault.burn_refunded_beth(REFUND_BETH_AMOUNT + 1, {'from': vault_admin})
+
+    beth_chunk_1 = REFUND_BETH_AMOUNT // 3
+
+    vault.burn_refunded_beth(beth_chunk_1, {'from': vault_admin})
+
+    with reverts():
+        vault.burn_refunded_beth(REFUND_BETH_AMOUNT - beth_chunk_1 + 1, {'from': vault_admin})
+
+
+def test_non_admin_cannot_burn_the_refunded_beth(vault_proxy, beth_token, stranger):
+    upgrade_vault_to_v3(vault_proxy, impl_deployer=stranger)
+    vault = as_vault_v3(vault_proxy)
+
+    # simulate the unlock of the refunded bETH
+    token_bridge = accounts.at(wormhole_token_bridge_addr, force=True)
+    beth_token.transfer(vault, REFUND_BETH_AMOUNT, {'from': token_bridge})
+
+    liquidations_admin = accounts.at(vault.liquidations_admin(), force=True)
+
+    with reverts():
+        vault.burn_refunded_beth(REFUND_BETH_AMOUNT, {'from': stranger})
+
+    with reverts():
+        vault.burn_refunded_beth(REFUND_BETH_AMOUNT, {'from': liquidations_admin})

--- a/tests/test_upgrade_v3.py
+++ b/tests/test_upgrade_v3.py
@@ -7,6 +7,9 @@ before the v3 upgrade, e.g. on the block 14158645.
 """
 
 MAINNET_VAULT = '0xA2F987A546D4CD1c607Ee8141276876C26b72Bdf'
+REFUND_BETH_AMOUNT = 4449999990000000000 + 439111118580000000000
+REFUND_MESSAGE = 'refund for 2022-01-26 incident, txid 0x7abe086dd5619a577f50f87660a03ea0a1934c4022cd432ddf00734771019951 and 0xc875f85f525d9bc47314eeb8dc13c288f0814cf06865fc70531241e21f5da09d'
+LIDO_DAO_FINANCE_MULTISIG = '0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb'
 
 
 def as_vault_v2(addr):
@@ -94,3 +97,40 @@ def test_finalize_upgrade_v3_cannot_be_called_on_v4_vault(vault_proxy, stranger,
 
     with reverts('unexpected contract version'):
         vault.finalize_upgrade_v3({'from': vault_admin})
+
+
+def test_upgrade_performs_the_refund(vault_proxy, steth_token, stranger, helpers):
+    vault = as_vault_v3(vault_proxy)
+
+    vault_steth_balance_before = steth_token.balanceOf(vault_proxy)
+    dao_steth_balance_before = steth_token.balanceOf(LIDO_DAO_FINANCE_MULTISIG)
+    beth_rate_before = vault.get_rate()
+    expected_refund_steth_amount = (REFUND_BETH_AMOUNT * 10**18) // beth_rate_before
+
+    tx = upgrade_vault_to_v3(vault_proxy, impl_deployer=stranger)
+
+    assert helpers.equal_with_precision(vault.get_rate(), beth_rate_before, 1)
+    assert vault.total_beth_refunded() == REFUND_BETH_AMOUNT
+
+    refund_evt = helpers.assert_single_event_named('Refunded', tx, source=vault)
+    assert refund_evt['recipient'] == LIDO_DAO_FINANCE_MULTISIG
+    assert refund_evt['beth_amount'] == REFUND_BETH_AMOUNT
+    assert refund_evt['comment'] == REFUND_MESSAGE
+    assert helpers.equal_with_precision(refund_evt['steth_amount'], expected_refund_steth_amount, 1000)
+
+    vault_steth_balance_change = steth_token.balanceOf(vault_proxy) - vault_steth_balance_before
+    assert helpers.equal_with_precision(vault_steth_balance_change, -expected_refund_steth_amount, 1000)
+
+    dao_steth_balance_change = steth_token.balanceOf(LIDO_DAO_FINANCE_MULTISIG) - dao_steth_balance_before
+    assert helpers.equal_with_precision(dao_steth_balance_change, -vault_steth_balance_change, 2)
+
+
+def test_cannot_finalize_upgrade_twice(vault_proxy, stranger, vault_admin):
+    upgrade_vault_to_v3(vault_proxy, impl_deployer=stranger)
+    vault = as_vault_v3(vault_proxy)
+
+    with reverts():
+        vault.finalize_upgrade_v3({'from': vault_admin})
+
+    with reverts():
+        vault.finalize_upgrade_v3({'from': stranger})

--- a/tests/test_upgrade_v3_backcompatibility.py
+++ b/tests/test_upgrade_v3_backcompatibility.py
@@ -1,0 +1,290 @@
+import pytest
+from collections import namedtuple
+from brownie import accounts, interface, Contract, AnchorVault, BridgeConnectorWormhole, chain
+
+from utils.mainnet_fork import chain_snapshot
+from utils.config import beth_token_addr, wormhole_token_bridge_addr
+
+
+MAINNET_VAULT = '0xA2F987A546D4CD1c607Ee8141276876C26b72Bdf'
+REFUND_BETH_AMOUNT = 4449999990000000000 + 439111118580000000000
+TERRA_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+
+
+def as_vault_v2(addr):
+    return Contract.from_abi('AnchorVault_v2', addr, interface.AnchorVault_v2.abi)
+
+
+def as_vault_v3(addr):
+    return Contract.from_abi('AnchorVault', addr, AnchorVault.abi)
+
+
+@pytest.fixture(scope='module')
+def vault_proxy(AnchorVaultProxy):
+    proxy = AnchorVaultProxy.at(MAINNET_VAULT)
+    vault = as_vault_v2(proxy)
+    assert vault.version() == 2
+    assert vault.admin() == proxy.proxy_getAdmin()
+    return proxy
+
+
+@pytest.fixture(scope='module')
+def beth_token(bEth):
+    return bEth.at(beth_token_addr)
+
+
+def upgrade_vault_to_v3(vault_proxy, impl_deployer):
+    proxy_admin = accounts.at(vault_proxy.proxy_getAdmin(), force=True)
+
+    new_impl = AnchorVault.deploy({'from': impl_deployer})
+    new_impl.petrify_impl({'from': impl_deployer})
+
+    setup_calldata = new_impl.finalize_upgrade_v3.encode_input()
+    return vault_proxy.proxy_upgradeTo(new_impl, setup_calldata, {'from': proxy_admin})
+
+
+def record_vault_state(vault, steth_token):
+    state = {}
+
+    state['admin'] = vault.admin()
+    state['beth_token'] = vault.beth_token()
+    state['steth_token'] = vault.steth_token()
+    state['bridge_connector'] = vault.bridge_connector()
+    state['rewards_liquidator'] = vault.rewards_liquidator()
+    state['insurance_connector'] = vault.insurance_connector()
+    state['anchor_rewards_distributor'] = vault.anchor_rewards_distributor()
+
+    state['liquidations_admin'] = vault.liquidations_admin()
+    state['no_liquidation_interval'] = vault.no_liquidation_interval()
+    state['restricted_liquidation_interval'] = vault.restricted_liquidation_interval()
+
+    state['last_liquidation_time'] = vault.last_liquidation_time()
+    state['last_liquidation_share_price'] = vault.last_liquidation_share_price()
+    state['last_liquidation_shares_burnt'] = vault.last_liquidation_shares_burnt()
+
+    state['version'] = vault.version()
+
+    state['get_rate'] = vault.get_rate()
+    state['can_deposit_or_withdraw'] = vault.can_deposit_or_withdraw()
+
+    state['steth_balance'] = steth_token.balanceOf(vault.address)
+
+    return state
+
+
+def record_vault_state_at(vault, steth, beth, wormhole_token_bridge, stranger, another_stranger, state_history, time_step):
+    state_history[time_step + '_stranger_steth_balance'] = steth.balanceOf(stranger)
+    state_history[time_step + '_stranger_beth_balance'] = beth.balanceOf(stranger)
+
+    state_history[time_step + '_another_stranger_steth_balance'] = steth.balanceOf(another_stranger)
+    state_history[time_step + '_another_stranger_beth_balance'] = beth.balanceOf(another_stranger)
+
+    state_history[time_step + '_wormhole_token_bridge_balance'] = beth.balanceOf(wormhole_token_bridge)
+
+
+def record_vault_state_history(vault, steth_token, beth_token, wormhole_token_bridge, stranger, another_stranger, liquidations_admin, lido_oracle_report):
+    state_history = {}
+
+    stranger_deposit_amount = 10 * 10 ** 18
+    another_stranger_deposit_amount = 0.42 * 10**18
+
+    record_vault_state_at(
+        vault,
+        steth_token,
+        beth_token,
+        wormhole_token_bridge,
+        stranger,
+        another_stranger,
+        state_history,
+        '0'
+    )
+
+    prev_beth_total_supply = beth_token.totalSupply()
+    vault.submit(
+        stranger_deposit_amount,
+        TERRA_ADDRESS,
+        '0x8bada2e',
+        vault.version(),
+        {'from': stranger, 'value': stranger_deposit_amount}
+    )
+    stranger_beth_amount = beth_token.totalSupply() - prev_beth_total_supply
+    
+    record_vault_state_at(
+        vault,
+        steth_token,
+        beth_token,
+        wormhole_token_bridge,
+        stranger,
+        another_stranger,
+        state_history,
+        '1'
+    )
+
+    lido_oracle_report(steth_rebase_mult=1.01)
+    vault.collect_rewards({'from': liquidations_admin})
+    assert vault.can_deposit_or_withdraw()
+
+    record_vault_state_at(
+        vault,
+        steth_token,
+        beth_token,
+        wormhole_token_bridge,
+        stranger,
+        another_stranger,
+        state_history,
+        '2'
+    )
+
+    prev_beth_total_supply = beth_token.totalSupply()
+    vault.submit(
+        another_stranger_deposit_amount,
+        TERRA_ADDRESS,
+        '0x8bada2e',
+        vault.version(),
+        {'from': another_stranger, 'value': another_stranger_deposit_amount}
+    )
+    another_stranger_beth_amount = beth_token.totalSupply() - prev_beth_total_supply
+
+    record_vault_state_at(
+        vault,
+        steth_token,
+        beth_token,
+        wormhole_token_bridge,
+        stranger,
+        another_stranger,
+        state_history,
+        '3'
+    )
+
+    lido_oracle_report(steth_rebase_mult=0.98)
+    vault.collect_rewards({'from': liquidations_admin})
+    assert vault.can_deposit_or_withdraw()
+
+    record_vault_state_at(
+        vault,
+        steth_token,
+        beth_token,
+        wormhole_token_bridge,
+        stranger,
+        another_stranger,
+        state_history,
+        '4'
+    )
+
+    # simulate bridging from Terra
+    token_bridge = accounts.at(wormhole_token_bridge_addr, force=True)
+    beth_token.transfer(stranger, stranger_beth_amount, {'from': token_bridge})
+    beth_token.transfer(another_stranger, another_stranger_beth_amount, {'from': token_bridge})
+    
+    # withdraw from stranger
+    vault.withdraw(stranger_beth_amount, vault.version(), {'from': stranger})
+
+    record_vault_state_at(
+        vault,
+        steth_token,
+        beth_token,
+        wormhole_token_bridge,
+        stranger,
+        another_stranger,
+        state_history,
+        '5'
+    )
+
+    # withdraw from another_stranger
+    vault.withdraw(another_stranger_beth_amount, vault.version(), {'from': another_stranger})
+
+    record_vault_state_at(
+        vault,
+        steth_token,
+        beth_token,
+        wormhole_token_bridge,
+        stranger,
+        another_stranger,
+        state_history,
+        '6'
+    )
+
+    return state_history
+
+
+ValueChanged = namedtuple('ValueChanged', ['from_val', 'to_val'])
+
+
+def dictdiff(from_dict, to_dict):
+  result = {}
+  
+  all_keys = from_dict.keys() | to_dict.keys()
+  for key in all_keys:
+    if from_dict.get(key) != to_dict.get(key):
+      result[key] = ValueChanged(from_dict.get(key), to_dict.get(key))
+  
+  return result
+
+
+def test_upgrade_affects_only_expected_contract_fields(vault_proxy, steth_token, stranger, helpers):
+    state_before = record_vault_state(as_vault_v2(vault_proxy), steth_token)
+    upgrade_vault_to_v3(vault_proxy, impl_deployer=stranger)
+    
+    vault_v3 = as_vault_v3(vault_proxy)
+    state_after = record_vault_state(vault_v3, steth_token)
+    
+    state_diff = dictdiff(state_before, state_after)
+
+    # check the number of elements in the diff 
+    assert len(state_diff) == 2
+
+    # state differ because of withdrawal rate rounding errors, but not greater than 100000 wei
+    assert helpers.equal_with_precision(
+        state_after['steth_balance'],
+        state_before['steth_balance'] - REFUND_BETH_AMOUNT,
+        1000
+    )
+
+    assert state_diff['version'] == ValueChanged(2, 3)
+
+    # check that added field equals REFUND_BETH_AMOUNT after v3 upgrade
+    assert vault_v3.total_beth_refunded() == REFUND_BETH_AMOUNT
+
+
+def test_rebases(vault_proxy, steth_token, stranger, another_stranger, lido_oracle_report, interface, helpers):
+    vault = as_vault_v3(vault_proxy)
+    beth_token = interface.ERC20(vault.beth_token())
+    wormhole_token_bridge = Contract.from_abi(
+        'BridgeConnectorWormhole',
+        vault.bridge_connector(),
+        BridgeConnectorWormhole.abi
+    ).wormhole_token_bridge()
+    liquidations_admin = accounts.at(vault.liquidations_admin(), force=True)
+
+    assert vault.version() == 2 
+
+    state_history_before = {}
+    state_history_after = {}
+    with chain_snapshot():
+        state_history_before = record_vault_state_history(
+            vault,
+            steth_token,
+            beth_token,
+            wormhole_token_bridge,
+            stranger,
+            another_stranger,
+            liquidations_admin,
+            lido_oracle_report
+        )
+
+    upgrade_vault_to_v3(vault_proxy, impl_deployer=stranger)
+    
+    with chain_snapshot():
+        state_history_after = record_vault_state_history(
+            vault,
+            steth_token,
+            beth_token,
+            wormhole_token_bridge,
+            stranger,
+            another_stranger,
+            liquidations_admin,
+            lido_oracle_report
+        )
+
+    # no diff in v2 and v3 versions in vaults math
+    assert dictdiff(state_history_before, state_history_after) == {}


### PR DESCRIPTION
Branched off `feat/contract-versioning-lip-10` (#17).

Withdraws stETH locked as the result of the incident as a part of the v3 upgrade.

The description of the decision space and the reasoning behind selecting the implementation from this PR is here: https://hackmd.io/@lido/rkwe2pUCY.