### PR TITLE
Feat: implement vault emergency stop

### DIFF
--- a/contracts/AnchorVault.vy
+++ b/contracts/AnchorVault.vy
@@ -62,6 +62,10 @@ event AdminChanged:
     new_admin: address
 
 
+event EmergencyAdminChanged:
+    new_emergency_admin: address
+
+
 event BridgeConnectorUpdated:
     bridge_connector: address
 
@@ -88,6 +92,14 @@ event VersionIncremented:
     new_version: uint256
 
 
+event OperationsStopped:
+    pass
+
+
+event OperationsResumed:
+    pass
+
+
 BETH_DECIMALS: constant(uint256) = 18
 
 # A constant used in `_can_deposit_or_withdraw` when comparing Lido share prices.
@@ -104,6 +116,9 @@ BETH_DECIMALS: constant(uint256) = 18
 # https://github.com/lidofinance/lido-dao/blob/eb33eb8/contracts/0.4.24/StETH.sol#L288
 #
 STETH_SHARE_PRICE_MAX_ERROR: constant(uint256) = 10
+
+# Aragon Agent contract of the Lido DAO
+LIDO_DAO_AGENT: constant(address) = 0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c
 
 # WARNING: since this contract is behind a proxy, don't change the order of the variables
 # and don't remove variables during the code upgrades. You can only append new variables
@@ -145,6 +160,9 @@ last_liquidation_shares_burnt: public(uint256)
 #
 version: public(uint256)
 
+emergency_admin: public(address)
+operations_allowed: public(bool)
+
 total_beth_refunded: public(uint256)
 
 
@@ -154,18 +172,30 @@ def _assert_version(_expected_version: uint256):
 
 
 @internal
+def _assert_not_stopped():
+    assert self.operations_allowed, "contract stopped"
+
+
+@internal
 def _assert_admin(addr: address):
     assert addr == self.admin # dev: unauthorized
 
 
 @internal
-def _initialize_v3():
+def _assert_dao_governance(addr: address):
+    assert addr == LIDO_DAO_AGENT # dev: unauthorized
+
+
+@internal
+def _initialize_v3(emergency_admin: address):
+    self.emergency_admin = emergency_admin
+    log EmergencyAdminChanged(emergency_admin)
     self.version = 3
     log VersionIncremented(3)
 
 
 @external
-def initialize(beth_token: address, steth_token: address, admin: address):
+def initialize(beth_token: address, steth_token: address, admin: address, emergency_admin: address):
     assert self.beth_token == ZERO_ADDRESS # dev: already initialized
     assert self.version == 0 # dev: already initialized
 
@@ -179,7 +209,7 @@ def initialize(beth_token: address, steth_token: address, admin: address):
     # we're explicitly allowing zero admin address for ossification
     self.admin = admin
     self.last_liquidation_share_price = Lido(steth_token).getPooledEthByShares(10**18)
-    self._initialize_v3()
+    self._initialize_v3(emergency_admin)
 
     log AdminChanged(admin)
 
@@ -193,6 +223,39 @@ def petrify_impl():
     self.version = MAX_UINT256
 
 
+@external
+def emergency_stop():
+    """
+    @dev Performs emergency stop of the contract. Can only be called
+    by the current emergency admin or by the current admin.
+
+    While contract is in the stopped state, the following functions revert:
+
+    * `submit`
+    * `withdraw`
+    * `collect_rewards`
+
+    See `resume`, `set_emergency_admin`.
+    """
+    assert msg.sender == self.emergency_admin or msg.sender == self.admin # dev: unauthorized
+    self._assert_not_stopped()
+    self.operations_allowed = False
+    log OperationsStopped()
+
+
+@external
+def resume():
+    """
+    @dev Resumes normal operations of the contract. Can only be called
+    by the Lido DAO governance contract.
+
+    See `emergency_stop`.
+    """
+    self._assert_dao_governance(msg.sender)
+    assert not self.operations_allowed # dev: not stopped
+    self.operations_allowed = True
+    log OperationsResumed()
+
 
 @external
 def change_admin(new_admin: address):
@@ -205,6 +268,21 @@ def change_admin(new_admin: address):
     # we're explicitly allowing zero admin address for ossification
     self.admin = new_admin
     log AdminChanged(new_admin)
+
+
+@external
+def set_emergency_admin(new_emergency_admin: address):
+    """
+    @dev Sets the address allowed to perform an emergency stop and having no other privileges.
+
+    Can only be called by the Lido DAO governance contract.
+
+    See `emergency_stop`, `resume`.
+    """
+    self._assert_dao_governance(msg.sender)
+    # we're explicitly allowing zero address
+    self.emergency_admin = new_emergency_admin
+    log EmergencyAdminChanged(new_emergency_admin)
 
 
 @external
@@ -417,7 +495,7 @@ def can_deposit_or_withdraw() -> bool:
     UST yet. Normally, this period should not last more than a couple of minutes
     each 24h.
     """
-    return self._can_deposit_or_withdraw()
+    return self.operations_allowed and self._can_deposit_or_withdraw()
 
 
 @external
@@ -444,6 +522,7 @@ def submit(
     severe penalties inflicted on the Lido validators. You can obtain the current conversion
     rate by calling `AnchorVault.get_rate()`.
     """
+    self._assert_not_stopped()
     self._assert_version(_expected_version)
     assert self._can_deposit_or_withdraw() # dev: share price changed
 
@@ -506,6 +585,7 @@ def withdraw(
     severe penalties inflicted on the Lido validators. You can obtain the current conversion
     rate by calling `AnchorVault.get_rate()`.
     """
+    self._assert_not_stopped()
     self._assert_version(_expected_version)
 
     steth_rate: uint256 = self._get_rate(True)
@@ -603,7 +683,7 @@ def _perform_refund_for_2022_01_26_incident():
 
 
 @external
-def finalize_upgrade_v3():
+def finalize_upgrade_v3(emergency_admin: address):
     """
     @dev Performs state changes required for proxy upgrade from version 2 to version 3.
 
@@ -614,7 +694,8 @@ def finalize_upgrade_v3():
     # the same function reads a storage slot that's zero until this function is called
     self._assert_version(0)
     self._perform_refund_for_2022_01_26_incident()
-    self._initialize_v3()
+    self._initialize_v3(emergency_admin)
+    self.operations_allowed = True
 
 
 @external
@@ -623,6 +704,8 @@ def collect_rewards() -> uint256:
     @dev Sells stETH rewards and transfers them to the distributor contract in the
          Terra blockchain.
     """
+    self._assert_not_stopped()
+
     time_since_last_liquidation: uint256 = block.timestamp - self.last_liquidation_time
 
     if msg.sender == self.liquidations_admin:

--- a/contracts/AnchorVault.vy
+++ b/contracts/AnchorVault.vy
@@ -35,11 +35,13 @@ event Deposited:
     sender: indexed(address)
     amount: uint256
     terra_address: bytes32
+    beth_amount_received: uint256
 
 
 event Withdrawn:
     recipient: indexed(address)
     amount: uint256
+    steth_amount_received: uint256
 
 
 event Refunded:
@@ -552,7 +554,7 @@ def submit(
     Mintable(self.beth_token).mint(connector, beth_amount)
     BridgeConnector(connector).forward_beth(_terra_address, beth_amount, _extra_data)
 
-    log Deposited(msg.sender, steth_amount_adj, _terra_address)
+    log Deposited(msg.sender, steth_amount_adj, _terra_address, beth_amount)
 
     return (steth_amount_adj, beth_amount)
 
@@ -592,7 +594,7 @@ def withdraw(
     Mintable(self.beth_token).burn(msg.sender, _beth_amount)
     steth_amount: uint256 = self._withdraw(_recipient, _beth_amount, steth_rate)
 
-    log Withdrawn(_recipient, _beth_amount)
+    log Withdrawn(_recipient, _beth_amount, steth_amount)
 
     return steth_amount
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,13 @@ def admin(accounts):
 
 
 @pytest.fixture(scope='module')
+def emergency_admin(accounts, deployer):
+    emergency_admin = accounts.add()
+    deployer.transfer(emergency_admin, 10 * 10**18)
+    return emergency_admin
+
+
+@pytest.fixture(scope='module')
 def liquidations_admin(accounts):
     return accounts[2]
 
@@ -69,6 +76,11 @@ def lido(interface, steth_token):
 
 
 @pytest.fixture(scope='module')
+def lido_dao_agent(accounts):
+    return accounts.at('0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c', force=True)
+
+
+@pytest.fixture(scope='module')
 def ust_token(interface):
     return interface.UST(UST_TOKEN)
 
@@ -77,17 +89,21 @@ def ust_token(interface):
 def usdc_token(interface):
     return interface.USDC(USDC_TOKEN)
 
+
 @pytest.fixture(scope='module')
 def feed_steth_eth(interface):
     return interface.Chainlink(CHAINLINK_STETH_ETH_FEED)
+
 
 @pytest.fixture(scope='module')
 def feed_usdc_eth(interface):
     return interface.Chainlink(CHAINLINK_USDC_ETH_FEED)
 
+
 @pytest.fixture(scope='module')
 def feed_ust_eth(interface):
     return interface.Chainlink(CHAINLINK_UST_ETH_FEED)
+
 
 @pytest.fixture(scope='module')
 def beth_token(deployer, admin, bEth):

--- a/tests/test_connector_wormhole.py
+++ b/tests/test_connector_wormhole.py
@@ -27,20 +27,22 @@ def vault(
     bridge_connector,
     mock_rewards_liquidator,
     mock_insurance_connector,
+    lido_dao_agent,
     deployer,
     admin,
     liquidations_admin,
+    emergency_admin,
     AnchorVault,
     AnchorVaultProxy
 ):
     impl = AnchorVault.deploy({'from': deployer})
-    impl.initialize(beth_token, steth_token, ZERO_ADDRESS, {'from': deployer})
+    impl.petrify_impl({'from': deployer})
 
     proxy = AnchorVaultProxy.deploy(impl, admin, {'from': deployer})
 
     vault = Contract.from_abi('AnchorVault', proxy.address, AnchorVault.abi)
 
-    vault.initialize(beth_token, steth_token, admin, {'from': deployer})
+    vault.initialize(beth_token, steth_token, admin, emergency_admin, {'from': deployer})
 
     vault.configure(
         bridge_connector,
@@ -54,6 +56,7 @@ def vault(
     )
 
     beth_token.set_minter(vault, {'from': admin})
+    vault.resume({'from': lido_dao_agent})
 
     return vault
 

--- a/tests/test_emergency_stop.py
+++ b/tests/test_emergency_stop.py
@@ -1,0 +1,284 @@
+import pytest
+from brownie import Contract, ZERO_ADDRESS, chain, reverts, ETH_ADDRESS
+
+from utils.mainnet_fork import chain_snapshot
+from test_vault import deploy_and_initialize_vault, resume_vault, TERRA_ADDRESS
+
+
+@pytest.fixture(scope='module')
+def actors(admin, deployer, stranger, lido_dao_agent, emergency_admin, liquidations_admin):
+    return {
+        'admin': admin,
+        'deployer': deployer,
+        'stranger': stranger,
+        'lido_dao_agent': lido_dao_agent,
+        'emergency_admin': emergency_admin,
+        'liquidations_admin': liquidations_admin
+    }
+
+
+@pytest.fixture(
+    scope='module',
+    params=['admin', 'deployer', 'stranger', 'emergency_admin', 'liquidations_admin']
+)
+def non_governance_actor(actors, request):
+    return actors[request.param]
+
+
+@pytest.fixture(scope='module', params=['admin', 'emergency_admin'])
+def emergency_admin_role(actors, request):
+    return actors[request.param]
+
+
+@pytest.fixture(scope='module', params=['deployer', 'stranger', 'lido_dao_agent', 'liquidations_admin'])
+def non_emergency_admin_role(actors, request):
+    return actors[request.param]
+
+
+@pytest.fixture(scope='module')
+def new_emergency_admin(accounts, deployer):
+    emergency_admin = accounts.add()
+    deployer.transfer(emergency_admin, 10 * 10**18)
+    return emergency_admin
+
+
+def test_vault_is_initialized_in_a_stopped_state(
+    AnchorVault,
+    admin,
+    beth_token,
+    steth_token,
+    mock_bridge_connector,
+    mock_rewards_liquidator,
+    mock_insurance_connector,
+):
+    # deploying from admin instead of deployer to work around a brownie bug
+    # leading to the brownie.exceptions.ContractNotFound
+    new_vault = AnchorVault.deploy({'from': admin})
+    assert not new_vault.operations_allowed()
+    assert not new_vault.can_deposit_or_withdraw()
+
+    new_vault.initialize(beth_token, steth_token, admin, admin, {'from': admin})
+    assert not new_vault.operations_allowed()
+    assert not new_vault.can_deposit_or_withdraw()
+
+    new_vault.configure(
+        mock_bridge_connector,
+        mock_rewards_liquidator,
+        mock_insurance_connector,
+        admin,
+        0,
+        60 * 60 * 26,
+        '0x1234123412341234123412341234123412341234123412341234123412341234',
+        {'from': admin}
+    )
+
+    assert not new_vault.operations_allowed()
+    assert not new_vault.can_deposit_or_withdraw()
+
+
+@pytest.fixture(scope='module')
+def initialized_vault_proxy(
+    beth_token,
+    steth_token,
+    mock_bridge_connector,
+    mock_rewards_liquidator,
+    mock_insurance_connector,
+    deployer,
+    stranger,
+    admin,
+    emergency_admin,
+    liquidations_admin,
+    lido_dao_agent,
+    AnchorVault,
+    AnchorVaultProxy,
+    helpers
+):
+    return deploy_and_initialize_vault(**locals())
+
+
+def test_dao_gov_can_set_emergency_admin(
+    initialized_vault_proxy,
+    lido_dao_agent,
+    new_emergency_admin,
+    helpers
+):
+    tx = initialized_vault_proxy.set_emergency_admin(new_emergency_admin, {'from': lido_dao_agent})
+
+    assert initialized_vault_proxy.emergency_admin() == new_emergency_admin
+
+    helpers.assert_single_event_named('EmergencyAdminChanged', tx,
+        source=initialized_vault_proxy,
+        evt_keys_dict={'new_emergency_admin': new_emergency_admin}
+    )
+
+
+def test_non_gov_cannot_set_emergency_admin(
+    initialized_vault_proxy,
+    non_governance_actor,
+    new_emergency_admin
+):
+    with reverts():
+        initialized_vault_proxy.set_emergency_admin(new_emergency_admin, {'from': non_governance_actor})
+
+
+def test_dao_gov_can_resume_deployed_contract(initialized_vault_proxy, lido_dao_agent, helpers):
+    tx = initialized_vault_proxy.resume({'from': lido_dao_agent})
+    assert initialized_vault_proxy.operations_allowed()
+    assert initialized_vault_proxy.can_deposit_or_withdraw()
+    helpers.assert_single_event_named('OperationsResumed', tx, source=initialized_vault_proxy)
+
+
+def test_non_gov_cannot_resume_deployed_contract(initialized_vault_proxy, non_governance_actor):
+    with reverts():
+        initialized_vault_proxy.resume({'from': non_governance_actor})
+
+
+@pytest.fixture(scope='function')
+def vault(initialized_vault_proxy, lido_dao_agent):
+    initialized_vault_proxy.resume({'from': lido_dao_agent})
+    return initialized_vault_proxy
+
+
+def test_emergency_admin_role_can_stop_running_contract(vault, emergency_admin_role, helpers):
+    tx = vault.emergency_stop({'from': emergency_admin_role})
+    assert not vault.operations_allowed()
+    assert not vault.can_deposit_or_withdraw()
+    helpers.assert_single_event_named('OperationsStopped', tx, source=vault)
+
+
+def test_non_emergency_admin_role_cannot_stop_running_contract(vault, non_emergency_admin_role):
+    with reverts():
+        vault.emergency_stop({'from': non_emergency_admin_role})
+
+
+def test_dao_gov_can_resume_stopped_contract(vault, emergency_admin, lido_dao_agent, helpers):
+    vault.emergency_stop({'from': emergency_admin})
+    assert not vault.operations_allowed()
+    assert not vault.can_deposit_or_withdraw()
+
+    tx = vault.resume({'from': lido_dao_agent})
+    assert vault.operations_allowed()
+    assert vault.can_deposit_or_withdraw()
+    helpers.assert_single_event_named('OperationsResumed', tx, source=vault)
+
+
+def test_new_emergency_admin_can_stop_running_contract(
+    vault,
+    new_emergency_admin,
+    lido_dao_agent,
+    helpers
+):
+    vault.set_emergency_admin(new_emergency_admin, {'from': lido_dao_agent})
+    tx = vault.emergency_stop({'from': new_emergency_admin})
+    assert not vault.operations_allowed()
+    assert not vault.can_deposit_or_withdraw()
+    helpers.assert_single_event_named('OperationsStopped', tx, source=vault)
+
+
+def test_stopped_contract_allows_no_deposits(vault, vault_user, emergency_admin, steth_token):
+    vault.emergency_stop({'from': emergency_admin})
+
+    amount = 10**18
+    steth_token.approve(vault, amount, {'from': vault_user})
+
+    assert not vault.can_deposit_or_withdraw()
+
+    with reverts('contract stopped'):
+        vault.submit(amount, TERRA_ADDRESS, '0xab', vault.version(), {'from': vault_user})
+
+    with reverts('contract stopped'):
+        vault.submit(amount, TERRA_ADDRESS, '0xab', vault.version(), {'from': vault_user, 'value': amount})
+
+
+def test_stopped_contract_allows_no_withdrawals(
+    vault,
+    vault_user,
+    emergency_admin,
+    withdraw_from_terra
+):
+    tx = vault.submit(10**18, TERRA_ADDRESS, '0xab', vault.version(), {'from': vault_user, 'value': 10**18})
+    beth_amount = tx.events['Deposited']['beth_amount_received']
+
+    vault.emergency_stop({'from': emergency_admin})
+    assert not vault.can_deposit_or_withdraw()
+
+    withdraw_from_terra(TERRA_ADDRESS, vault_user, beth_amount)
+
+    with reverts('contract stopped'):
+        vault.withdraw(beth_amount, vault.version(), {'from': vault_user})
+
+
+def test_stopped_contract_allows_no_rewards_collection(
+    vault,
+    vault_user,
+    emergency_admin,
+    liquidations_admin,
+    lido_oracle_report
+):
+    vault.submit(10**18, TERRA_ADDRESS, '0xab', vault.version(), {'from': vault_user, 'value': 10**18})
+    vault.emergency_stop({'from': emergency_admin})
+
+    lido_oracle_report(steth_rebase_mult=1.01)
+
+    with reverts('contract stopped'):
+        vault.collect_rewards({'from': liquidations_admin})
+
+
+
+def test_unhappy_path(
+    initialized_vault_proxy,
+    vault_user,
+    steth_token,
+    lido_dao_agent,
+    emergency_admin,
+    liquidations_admin,
+    lido_oracle_report,
+    withdraw_from_terra,
+    helpers
+):
+    vault = initialized_vault_proxy
+    assert not vault.operations_allowed()
+    assert not vault.can_deposit_or_withdraw()
+
+    def assert_operations_revert():
+        steth_token.approve(vault, 10**18, {'from': vault_user})
+
+        with reverts('contract stopped'):
+            vault.submit(10**18, TERRA_ADDRESS, '0xab', vault.version(), {'from': vault_user})
+
+        with reverts('contract stopped'):
+            vault.submit(10**18, TERRA_ADDRESS, '0xab', vault.version(), {'from': vault_user, 'value': 10**18})
+
+        with chain_snapshot():
+            lido_oracle_report(steth_rebase_mult=1.01)
+            with reverts('contract stopped'):
+                vault.collect_rewards({'from': liquidations_admin})
+
+    assert_operations_revert()
+
+    vault.resume({'from': lido_dao_agent})
+    assert vault.operations_allowed()
+    assert vault.can_deposit_or_withdraw()
+
+    tx = vault.submit(10**18, TERRA_ADDRESS, '0xab', vault.version(), {'from': vault_user, 'value': 10**18})
+    beth_amount = tx.events['Deposited']['beth_amount_received']
+
+    vault.emergency_stop({'from': emergency_admin})
+    assert not vault.operations_allowed()
+    assert not vault.can_deposit_or_withdraw()
+
+    withdraw_from_terra(TERRA_ADDRESS, vault_user, beth_amount)
+    assert_operations_revert()
+
+    vault.resume({'from': lido_dao_agent})
+    assert vault.operations_allowed()
+    assert vault.can_deposit_or_withdraw()
+
+    lido_oracle_report(steth_rebase_mult=1.01)
+    tx = vault.collect_rewards({'from': liquidations_admin})
+    helpers.assert_single_event_named('RewardsCollected', tx, source=vault)
+    assert vault.can_deposit_or_withdraw()
+
+    tx = vault.withdraw(beth_amount, vault.version(), {'from': vault_user})
+    evt = helpers.assert_single_event_named('Withdrawn', tx, source=vault)
+    assert evt['amount'] == beth_amount

--- a/tests/test_upgrade_v3.py
+++ b/tests/test_upgrade_v3.py
@@ -87,6 +87,12 @@ def test_upgrade_changes_version_to_3(vault_proxy, stranger, emergency_admin, he
     })
 
 
+def test_upgrade_doesnt_stop_the_contract(vault_proxy, stranger, emergency_admin, helpers):
+    tx = upgrade_vault_to_v3(vault_proxy, impl_deployer=stranger, emergency_admin=emergency_admin)
+    vault = as_vault_v3(vault_proxy)
+    assert vault.operations_allowed()
+
+
 def test_finalize_upgrade_v3_cannot_be_called_twice(vault_proxy, stranger, vault_admin, emergency_admin):
     tx = upgrade_vault_to_v3(vault_proxy, impl_deployer=stranger, emergency_admin=emergency_admin)
     vault = as_vault_v3(vault_proxy)

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -18,26 +18,26 @@ VAULT_VERSION = 3
 def test_init_cannot_be_called_twice(beth_token, steth_token, deployer, admin, stranger, AnchorVault):
     vault = AnchorVault.deploy({'from': deployer})
 
-    vault.initialize(beth_token, steth_token, admin, {'from': stranger})
+    vault.initialize(beth_token, steth_token, admin, admin, {'from': stranger})
 
     with reverts('dev: already initialized'):
-        vault.initialize(beth_token, steth_token, admin, {'from': stranger})
+        vault.initialize(beth_token, steth_token, admin, admin, {'from': stranger})
 
     with reverts('dev: already initialized'):
-        vault.initialize(beth_token, steth_token, admin, {'from': deployer})
+        vault.initialize(beth_token, steth_token, admin, admin, {'from': deployer})
 
     with reverts('dev: already initialized'):
-        vault.initialize(beth_token, steth_token, admin, {'from': admin})
+        vault.initialize(beth_token, steth_token, admin, admin, {'from': admin})
 
 
 def test_init_fails_on_zero_token_address(beth_token, steth_token, deployer, admin, AnchorVault):
     vault = AnchorVault.deploy({'from': deployer})
 
     with reverts('dev: invalid bETH address'):
-        vault.initialize(ZERO_ADDRESS, steth_token, admin, {'from': deployer})
+        vault.initialize(ZERO_ADDRESS, steth_token, admin, admin, {'from': deployer})
 
     with reverts('dev: invalid stETH address'):
-        vault.initialize(beth_token, ZERO_ADDRESS, admin, {'from': deployer})
+        vault.initialize(beth_token, ZERO_ADDRESS, admin, admin, {'from': deployer})
 
 
 def test_init_fails_on_non_zero_beth_total_supply(
@@ -53,7 +53,7 @@ def test_init_fails_on_non_zero_beth_total_supply(
     vault = AnchorVault.deploy({'from': deployer})
 
     with reverts('dev: non-zero bETH total supply'):
-        vault.initialize(beth_token, steth_token, admin, {'from': deployer})
+        vault.initialize(beth_token, steth_token, admin, admin, {'from': deployer})
 
 
 def test_initialized_vault_cannot_be_petrified(
@@ -65,7 +65,7 @@ def test_initialized_vault_cannot_be_petrified(
     AnchorVault
 ):
     vault = AnchorVault.deploy({'from': deployer})
-    vault.initialize(beth_token, steth_token, admin, {'from': stranger})
+    vault.initialize(beth_token, steth_token, admin, admin, {'from': stranger})
 
     with reverts('dev: already initialized'):
         vault.petrify_impl({'from': stranger})
@@ -88,14 +88,13 @@ def test_petrified_vault_cannot_be_initialized(
     vault.petrify_impl({'from': stranger})
 
     with reverts('dev: already initialized'):
-        vault.initialize(beth_token, steth_token, stranger, {'from': stranger})
+        vault.initialize(beth_token, steth_token, stranger, stranger, {'from': stranger})
 
     with reverts('dev: already initialized'):
-        vault.initialize(beth_token, steth_token, deployer, {'from': deployer})
+        vault.initialize(beth_token, steth_token, deployer, deployer, {'from': deployer})
 
 
-@pytest.fixture(scope='module')
-def vault(
+def deploy_and_initialize_vault(
     beth_token,
     steth_token,
     mock_bridge_connector,
@@ -104,7 +103,9 @@ def vault(
     deployer,
     stranger,
     admin,
+    emergency_admin,
     liquidations_admin,
+    lido_dao_agent,
     AnchorVault,
     AnchorVaultProxy,
     helpers
@@ -117,18 +118,22 @@ def vault(
     assert impl.steth_token() == ZERO_ADDRESS
 
     with reverts('dev: already initialized'):
-        impl.initialize(beth_token, steth_token, stranger, {'from': stranger})
+        impl.initialize(beth_token, steth_token, stranger, stranger, {'from': stranger})
 
     with reverts('dev: already initialized'):
-        impl.initialize(beth_token, steth_token, deployer, {'from': deployer})
+        impl.initialize(beth_token, steth_token, deployer, deployer, {'from': deployer})
 
     proxy = AnchorVaultProxy.deploy(impl, admin, {'from': deployer})
     vault = Contract.from_abi('AnchorVault', proxy.address, AnchorVault.abi)
 
-    tx = vault.initialize(beth_token, steth_token, admin, {'from': stranger})
+    tx = vault.initialize(beth_token, steth_token, admin, emergency_admin, {'from': stranger})
 
     helpers.assert_single_event_named('AdminChanged', tx, source=vault, evt_keys_dict={
         'new_admin': admin
+    })
+
+    helpers.assert_single_event_named('EmergencyAdminChanged', tx, source=vault, evt_keys_dict={
+        'new_emergency_admin': emergency_admin
     })
 
     helpers.assert_single_event_named('VersionIncremented', tx, source=vault, evt_keys_dict={
@@ -151,6 +156,36 @@ def vault(
     return vault
 
 
+def resume_vault(vault, lido_dao_agent):
+    assert not vault.operations_allowed()
+    vault.resume({'from': lido_dao_agent})
+    assert vault.operations_allowed()
+    return vault
+
+
+
+@pytest.fixture(scope='module')
+def vault(
+    beth_token,
+    steth_token,
+    mock_bridge_connector,
+    mock_rewards_liquidator,
+    mock_insurance_connector,
+    deployer,
+    stranger,
+    admin,
+    emergency_admin,
+    liquidations_admin,
+    lido_dao_agent,
+    AnchorVault,
+    AnchorVaultProxy,
+    helpers
+):
+    vault = deploy_and_initialize_vault(**locals())
+    resume_vault(vault, lido_dao_agent)
+    return vault
+
+
 @pytest.fixture(scope='function')
 def vault_no_proxy(
     beth_token,
@@ -160,12 +195,14 @@ def vault_no_proxy(
     mock_insurance_connector,
     deployer,
     admin,
+    emergency_admin,
     liquidations_admin,
+    lido_dao_agent,
     AnchorVault
 ):
     vault = AnchorVault.deploy({'from': deployer})
 
-    vault.initialize(beth_token, steth_token, admin, {'from': deployer})
+    vault.initialize(beth_token, steth_token, admin, emergency_admin, {'from': deployer})
 
     vault.configure(
         mock_bridge_connector,
@@ -179,6 +216,7 @@ def vault_no_proxy(
     )
 
     beth_token.set_minter(vault, {'from': admin})
+    resume_vault(vault, lido_dao_agent)
 
     return vault
 
@@ -186,6 +224,7 @@ def vault_no_proxy(
 def test_initial_config_correct(
     vault,
     admin,
+    emergency_admin,
     beth_token,
     lido,
     mock_bridge_connector,
@@ -194,6 +233,7 @@ def test_initial_config_correct(
     liquidations_admin
 ):
     assert vault.admin() == admin
+    assert vault.emergency_admin() == emergency_admin
     assert vault.version() == VAULT_VERSION
     assert vault.beth_token() == beth_token
     assert vault.bridge_connector() == mock_bridge_connector
@@ -206,7 +246,7 @@ def test_initial_config_correct(
 
 def test_finalize_upgrade_v3_cannot_be_called_on_v3_vault(vault, admin):
     with reverts('unexpected contract version'):
-        vault.finalize_upgrade_v3({'from': admin})
+        vault.finalize_upgrade_v3(admin, {'from': admin})
 
 
 def test_version_can_be_bumped_by_admin(vault, admin, helpers):
@@ -220,18 +260,25 @@ def test_version_can_be_bumped_by_admin(vault, admin, helpers):
 
 # FIXME: use vault instead of vault_no_proxy after brownie learns to parse
 # dev revert reasons from behind a proxy
-def test_version_cannot_be_bumped_by_a_non_admin(vault_no_proxy, stranger, liquidations_admin):
+def test_version_cannot_be_bumped_by_a_non_admin(
+    vault_no_proxy,
+    stranger,
+    liquidations_admin,
+    emergency_admin
+):
     with reverts('dev: unauthorized'):
         vault_no_proxy.bump_version({'from': stranger})
     with reverts('dev: unauthorized'):
         vault_no_proxy.bump_version({'from': liquidations_admin})
+    with reverts('dev: unauthorized'):
+        vault_no_proxy.bump_version({'from': emergency_admin})
 
 
 def test_finalize_upgrade_v3_cannot_be_called_on_v4_vault(vault, admin):
     vault.bump_version({'from': admin})
     assert vault.version() == 4
     with reverts('unexpected contract version'):
-        vault.finalize_upgrade_v3({'from': admin})
+        vault.finalize_upgrade_v3(admin, {'from': admin})
 
 
 @pytest.mark.parametrize('amount', [1 * 10**18, 1 * 10**18 + 10])


### PR DESCRIPTION
Allows the DAO governance to assign an address that can perform an emergency stop of the contract, disabling the following:

* stETH and ETH deposits (bETH minting);
* stETH withdrawals (bETH burning);
* selling stETH rewards to UST.

After the vault is stopped, it can only be resumed by the DAO governance.

Includes one unrelated (but important for the testing code) feature: `Deposited` and `Withdrawn` events now include the bETH amount minted and stETH amount released, respectively.